### PR TITLE
Issue/4/create dashboard

### DIFF
--- a/src/app/_refine_context.tsx
+++ b/src/app/_refine_context.tsx
@@ -3,6 +3,8 @@
 import { AuthProvider, GitHubBanner, Refine } from '@refinedev/core'
 import { RefineKbar, RefineKbarProvider } from '@refinedev/kbar'
 import { RefineSnackbarProvider, useNotificationProvider } from '@refinedev/mui'
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react'
 import { usePathname } from 'next/navigation'
 import React from 'react'
@@ -103,6 +105,29 @@ const App = (props: React.PropsWithChildren<AppProps>) => {
               routerProvider={routerProvider}
               dataProvider={dataProvider}
               notificationProvider={useNotificationProvider}
+              resources={[
+                {
+                  name: 'HOME',
+                  list: '/home',
+                  meta: {
+                    icon: <HomeOutlinedIcon />,
+                  },
+                  options: {
+                    label: 'ホーム',
+                  },
+                },
+                {
+                  name: 'posts',
+                  list: '/posts',
+                  meta: {
+                    canDelete: true,
+                    icon: <ArticleOutlinedIcon />,
+                  },
+                  options: {
+                    label: '投稿',
+                  },
+                },
+              ]}
               authProvider={authProvider}
               options={{
                 syncWithLocation: true,

--- a/src/app/home/layout.tsx
+++ b/src/app/home/layout.tsx
@@ -1,0 +1,30 @@
+import authOptions from '@app/api/auth/[...nextauth]/options'
+import { ThemedLayout } from '@components/ThemedLayout/ThemedLayout'
+import { getServerSession } from 'next-auth/next'
+import { redirect } from 'next/navigation'
+import React from 'react'
+
+export async function generateMetadata() {
+  return {
+    title: 'ホーム',
+    description: 'ホーム画面',
+  }
+}
+
+export default async function Layout({ children }: React.PropsWithChildren) {
+  const data = await getData()
+
+  if (!data.session?.user) {
+    return redirect('/login')
+  }
+
+  return <ThemedLayout>{children}</ThemedLayout>
+}
+
+async function getData() {
+  const session = await getServerSession(authOptions)
+
+  return {
+    session,
+  }
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Home Page</h1>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
+import WebAssetOutlinedIcon from '@mui/icons-material/WebAssetOutlined'
 import { useLogin } from '@refinedev/core'
 import { ThemedTitleV2 } from '@refinedev/mui'
 
@@ -26,6 +27,8 @@ export default function Login() {
             fontSize: '22px',
             justifyContent: 'center',
           }}
+          icon={<WebAssetOutlinedIcon />}
+          text='くしくし話 管理画面'
         />
 
         <Button style={{ width: '240px' }} variant='contained' size='large' onClick={() => login({})}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,15 @@
 'use client'
+
 import { Suspense } from 'react'
-import { WelcomePage } from '@refinedev/core'
-import { Header } from '@components/Header/Header'
+import { NavigateToResource } from '@refinedev/nextjs-router'
+import { Authenticated } from '@refinedev/core'
 
 export default function IndexPage() {
   return (
     <Suspense>
-      <Header />
-      {/* <WelcomePage /> */}
+      <Authenticated key='home-page'>
+        <NavigateToResource />
+      </Authenticated>
     </Suspense>
   )
 }

--- a/src/app/posts/layout.tsx
+++ b/src/app/posts/layout.tsx
@@ -1,0 +1,30 @@
+import authOptions from '@app/api/auth/[...nextauth]/options'
+import { ThemedLayout } from '@components/ThemedLayout/ThemedLayout'
+import { getServerSession } from 'next-auth/next'
+import { redirect } from 'next/navigation'
+import React from 'react'
+
+export async function generateMetadata() {
+  return {
+    title: '投稿一覧',
+    description: '投稿一覧',
+  }
+}
+
+export default async function Layout({ children }: React.PropsWithChildren) {
+  const data = await getData()
+
+  if (!data.session?.user) {
+    return redirect('/login')
+  }
+
+  return <ThemedLayout>{children}</ThemedLayout>
+}
+
+async function getData() {
+  const session = await getServerSession(authOptions)
+
+  return {
+    session,
+  }
+}

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function PostsPage() {
+  return (
+    <div>
+      <h1>Posts Page</h1>
+    </div>
+  )
+}

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -7,11 +7,11 @@ type AppProps = {
 }
 
 export default function CircularIndeterminate({ defaultMode }: AppProps) {
-  const bgColor = defaultMode === 'dark' ? 'background_black' : 'background_white'
+  const bgColor = defaultMode === 'dark' ? 'zinc-800' : 'background_white'
 
   return (
     <div className={`grid place-items-center h-dvh w-dvw bg-${bgColor}`}>
-      <Box sx={{ display: 'flex' }}>
+      <Box>
         <CircularProgress />
       </Box>
     </div>

--- a/src/components/LogoutButton/LogoutButton.tsx
+++ b/src/components/LogoutButton/LogoutButton.tsx
@@ -1,12 +1,13 @@
-import { Button } from '@mui/material'
+import { IconButton } from '@mui/material'
+import LogoutIcon from '@mui/icons-material/Logout'
 import { useLogout } from '@refinedev/core'
 
 export default function LogoutButton() {
   const { mutate: logout } = useLogout()
 
   return (
-    <Button className='ml-4' onClick={() => logout({})} variant='contained' color='error'>
-      ログアウト
-    </Button>
+    <IconButton className='ml-2' onClick={() => logout({})} color='inherit'>
+      <LogoutIcon />
+    </IconButton>
   )
 }

--- a/src/components/ThemedLayout/ThemedLayout.tsx
+++ b/src/components/ThemedLayout/ThemedLayout.tsx
@@ -1,9 +1,24 @@
 'use client'
 
 import { Header } from '@components/Header/Header'
-import { ThemedLayoutV2 } from '@refinedev/mui'
+import { ThemedLayoutV2, ThemedTitleV2 } from '@refinedev/mui'
+import WebAssetOutlinedIcon from '@mui/icons-material/WebAssetOutlined'
+import WebAssetSharpIcon from '@mui/icons-material/WebAssetSharp'
 import React from 'react'
 
 export const ThemedLayout = ({ children }: React.PropsWithChildren) => {
-  return <ThemedLayoutV2 Header={() => <Header sticky />}>{children}</ThemedLayoutV2>
+  return (
+    <ThemedLayoutV2
+      Title={({ collapsed }) => (
+        <ThemedTitleV2
+          collapsed={collapsed}
+          icon={collapsed ? <WebAssetSharpIcon /> : <WebAssetOutlinedIcon />}
+          text='くしくし話 管理画面'
+        />
+      )}
+      Header={() => <Header sticky />}
+    >
+      {children}
+    </ThemedLayoutV2>
+  )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,22 +19,11 @@
       }
     ],
     "paths": {
-      "@*": [
-        "./src/*"
-      ],
-      "@pages/*": [
-        "./pages/*"
-      ]
+      "@*": ["./src/*"],
+      "@pages/*": ["./pages/*"]
     },
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 対応内容

- ホーム画面の作成
- Posts画面（ディレクトリ）の作成
- リファクタリング
- ログアウトボタンをアイコンに変更
- ログイン画面のタイトルとアイコンを変更
- 管理画面のレイアウト

## 備考

- [x] approveの場合はmerge可
- [ ] npm install 必要
- [ ] commonパッケージ更新あり

## 対応issue

close #4 


## 参考資料

[Refine resources｜Refine](https://refine.dev/docs/core/refine-component/#resources)
[Refine themed layout｜Refine](https://refine.dev/docs/ui-integrations/mantine/components/themed-layout/#title)
[Material icons｜MUI](https://mui.com/material-ui/material-icons/)